### PR TITLE
Read dialog output when using Extra button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,5 @@ group :development do
   gem "bundler", "~> 1.0"
   gem "juwelier", "~> 2.1.0"
   gem "simplecov", ">= 0"
+  gem "test-unit"
 end

--- a/lib/mrdialog/mrdialog.rb
+++ b/lib/mrdialog/mrdialog.rb
@@ -445,8 +445,9 @@ class MRDialog
     if @exit_code != 1
       tag = tmp.read
     end
-    tmp.close!
     return tag
+  ensure
+    tmp.close!
   end
    
   #
@@ -535,8 +536,9 @@ class MRDialog
         selected_tags << tag if tag.to_s.length > 0
       end
     end
-    tmp.close!
     return selected_tags
+  ensure
+    tmp.close!
   end
 
   # A  pause  box displays a meter along the bottom of the box.  The
@@ -604,8 +606,9 @@ class MRDialog
     if @exit_code == 0
       result = tmp.read
     end
-    tmp.close!
     return result
+  ensure
+    tmp.close!
   end
 
   #
@@ -701,8 +704,9 @@ class MRDialog
       end
     end
 
-    tmp.close!
     return res_hash
+  ensure
+    tmp.close!
   end
 
   #
@@ -756,13 +760,12 @@ class MRDialog
     @exit_code = $?.exitstatus
     if @exit_code != 1
       date = Date::civil(*tmp.readline.split('/').collect {|i| i.to_i}.reverse)
-      tmp.close!
       return date
     else
-      tmp.close!
       return success
     end  
-    
+  ensure    
+    tmp.close!
   end
 
   # A  checklist  box  is similar to a menu box; there are multiple
@@ -802,7 +805,6 @@ class MRDialog
     selected_array = []
     if @exit_code != 1
       selected_string = tmp.readline
-      tmp.close!
       log_debug "Separator: #{@separator}"
 
       sep = Shellwords.escape(@separator)
@@ -813,10 +815,10 @@ class MRDialog
       end
       return selected_array
     else
-      tmp.close!
       return success
     end
-
+  ensure    
+    tmp.close!
   end
 
   #      The file-selection dialog displays a text-entry window in which
@@ -856,12 +858,12 @@ class MRDialog
       rescue EOFError
         selected_string = ""
       end
-      tmp.close!
       return selected_string
     else
-      tmp.close!
       return success
     end
+  ensure
+    tmp.close!
   end
 
 
@@ -914,15 +916,14 @@ class MRDialog
     success = system(command)
     @exit_code = $?.exitstatus
 
-    if success
+    if @exit_code != 1
       selected_string = tmp.readline
-      tmp.close!
       return selected_string
     else
-      tmp.close!
       return success
     end
-
+  ensure    
+    tmp.close!
   end
 
         #      As  its  name  suggests, a menu box is a dialog box that can be
@@ -961,15 +962,14 @@ class MRDialog
     success = system(command)
     @exit_code = $?.exitstatus
 
-    if success
+    if @exit_code != 1
       selected_string = tmp.readline
-      tmp.close!
       return selected_string
     else
-      tmp.close!
       return success
     end
-    
+  ensure    
+    tmp.close!
   end
 
   #      A message box is very similar to a yes/no box.  The  only  dif-
@@ -1012,18 +1012,18 @@ class MRDialog
     success = system(command)
     @exit_code = $?.exitstatus
 
-    if success
+    if @exit_code != 1
       begin
         selected_string = tmp.readline
       rescue EOFError
         selected_string = ""
       end
-      tmp.close!
       return selected_string
     else
-      tmp.close!
       return success
     end
+  ensure
+    tmp.close!
   end
 
   #     The textbox method handles three similar dialog functions, textbox,
@@ -1093,15 +1093,14 @@ class MRDialog
     log_debug("Command:\n#{command}")
     success = system(command)
     @exit_code = $?.exitstatus
-    if success
+    if @exit_code != 1
       time = Time.parse(tmp.readline)
-      tmp.close!
       return time
     else
-      tmp.close!
       return success
     end
-    
+  ensure    
+    tmp.close!
   end
 
   #      An input box is useful when you  want  to  ask  questions  that
@@ -1129,18 +1128,18 @@ class MRDialog
     success = system(command)
     @exit_code = $?.exitstatus
 
-    if success
+    if @exit_code != 1
       begin
         selected_string = tmp.readline
       rescue EOFError
         selected_string = ""
       end
-      tmp.close!      
       return selected_string
     else
-      tmp.close!
       return success
     end
+  ensure
+    tmp.close!
   end
 
   #      A yes/no dialog box of size height rows by width  columns  will

--- a/lib/mrdialog/mrdialog.rb
+++ b/lib/mrdialog/mrdialog.rb
@@ -442,7 +442,7 @@ class MRDialog
     @exit_code = $?.exitstatus
     log_debug "Exit code: #{exit_code}"
     tag = ''
-    if @exit_code == 0
+    if @exit_code != 1
       tag = tmp.read
     end
     tmp.close!

--- a/lib/mrdialog/mrdialog.rb
+++ b/lib/mrdialog/mrdialog.rb
@@ -525,7 +525,7 @@ class MRDialog
     system(cmd)
     @exit_code = $?.exitstatus
     log_debug "Exit code: #{exit_code}"
-    if @exit_code == 0
+    if @exit_code != 1
       lines = tmp.read
       log_debug "lines: #{lines} #{lines.class}"
       sep = Shellwords.escape(@separator)
@@ -693,7 +693,7 @@ class MRDialog
     @exit_code = $?.exitstatus
     log_debug "Exit code: #{exit_code}"
 
-    if @exit_code == 0
+    if @exit_code != 1
       lines = tmp.readlines
       lines.each_with_index do |val, idx|
           key = items[idx][0]
@@ -754,7 +754,7 @@ class MRDialog
       " 2> " + tmp.path
     success = system(command)
     @exit_code = $?.exitstatus
-    if success
+    if @exit_code != 1
       date = Date::civil(*tmp.readline.split('/').collect {|i| i.to_i}.reverse)
       tmp.close!
       return date

--- a/lib/mrdialog/mrdialog.rb
+++ b/lib/mrdialog/mrdialog.rb
@@ -800,7 +800,7 @@ class MRDialog
     success = system(command)
     @exit_code = $?.exitstatus
     selected_array = []
-    if success
+    if @exit_code != 1
       selected_string = tmp.readline
       tmp.close!
       log_debug "Separator: #{@separator}"
@@ -850,7 +850,7 @@ class MRDialog
     success = system(command)
     @exit_code = $?.exitstatus
 
-    if success
+    if @exit_code != 1
       begin
         selected_string = tmp.readline
       rescue EOFError

--- a/samples/extra_button/buildlist.rb
+++ b/samples/extra_button/buildlist.rb
@@ -1,0 +1,89 @@
+#!/usr/bin/env ruby
+
+require [File.expand_path(File.dirname(__FILE__)), '../..', 'lib', 'mrdialog'].join('/')
+require 'pp'
+
+begin
+    ME = File.basename($0)
+    if ENV['CHANGE_TITLE']
+      if ME =~ /(.+)\.rb$/
+        base = $1
+        puts "\033]0;mrdialog - #{base}\007"
+      end
+    end
+    text = <<EOF
+This example is taken from dialog/samples/menulist
+shell script.
+
+Hi, this is a buildlist dialog. The list on the left
+shows the unselected items. The list on the right shows
+the selected  items.  Use SPACE bar to select/unselect 
+items. Shadow is set to false.
+
+EOF
+    items = []
+    Struct.new("BuildListData", :tag, :item, :status)
+    data = Struct::BuildListData.new
+
+    data.tag = "1"
+    data.item = "Item number 1"
+    data.status = true
+    items.push(data.to_a)
+
+    data = Struct::BuildListData.new
+    data.tag = "2"
+    data.item = "Item number 2"
+    data.status = false
+    items.push(data.to_a)
+
+    data = Struct::BuildListData.new
+    data.tag = "3"
+    data.item = "Item number 3"
+    data.status = false
+    items.push(data.to_a)
+
+    data = Struct::BuildListData.new
+    data.tag = "4"
+    data.item = "Item number 4"
+    data.status = true
+    items.push(data.to_a)
+
+    data = Struct::BuildListData.new
+    data.tag = "5"
+    data.item = "Item number 5"
+    data.status = false
+    items.push(data.to_a)
+
+    data = Struct::BuildListData.new
+    data.tag = "6"
+    data.item = "Item number 6"
+    data.status = true
+    items.push(data.to_a)
+
+    dialog = MRDialog.new
+    dialog.clear = true
+    dialog.shadow = false
+    dialog.title = "BUILDLIST"
+    dialog.logger = Logger.new(ENV["HOME"] + "/dialog_" + ME + ".log")
+    dialog.extra_button = true
+    dialog.ok_label = "Send"
+    dialog.extra_label = "Archive"
+    dialog.cancel_label = "Quit"
+
+    height = 0
+    width = 0
+    listheight = 0
+
+    selected_items = dialog.buildlist(text, items, height, width, listheight)
+    exit_code = dialog.exit_code
+    puts "Exit code: #{exit_code}"
+    puts "Selecetd tags:"
+    selected_items.each do |item|
+      puts " '#{item}'"
+    end
+
+rescue => e
+    puts "#{$!}"
+    t = e.backtrace.join("\n\t")
+    puts "Error: #{t}"
+end

--- a/samples/extra_button/calendar.rb
+++ b/samples/extra_button/calendar.rb
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+
+########################################################################
+# Example for calendar widget. 
+# muquit@muquit.com Apr-02-2014 
+########################################################################
+#
+require [File.expand_path(File.dirname(__FILE__)), '../..', 'lib', 'mrdialog'].join('/')
+require 'date'
+
+begin
+    ME = File.basename($0)
+    if ENV['CHANGE_TITLE']
+      if ME =~ /(.+)\.rb$/
+        base = $1
+        puts "\033]0;mrdialog - #{base}\007"
+      end
+    end
+
+    text = "Please choose a date..."
+
+    height = 0
+    width = 0
+    day = Date.today.mday
+    month =Date.today.mon
+    year =Date.today.year
+
+    dialog = MRDialog.new
+    dialog.logger = Logger.new(ENV["HOME"] + "/dialog_" + ME + ".log")
+    dialog.clear = true
+    dialog.title = "CALENDAR"
+    dialog.extra_button = true
+    dialog.ok_label = "Save"
+    dialog.extra_label = "Send"
+    dialog.cancel_label = "Quit"
+
+    date = dialog.calendar(text, height, width, day, month, year)
+    puts "Exit code: #{dialog.exit_code}"
+    puts "Result is: #{date.to_s}"
+
+rescue => e
+    puts "#{$!}"
+    t = e.backtrace.join("\n\t")
+    puts "Error: #{t}"
+end

--- a/samples/extra_button/checklist.rb
+++ b/samples/extra_button/checklist.rb
@@ -1,0 +1,84 @@
+#!/usr/bin/env ruby
+
+require [File.expand_path(File.dirname(__FILE__)), '../..', 'lib', 'mrdialog'].join('/')
+require 'pp'
+
+begin
+    ME = File.basename($0)
+    if ENV['CHANGE_TITLE']
+      if ME =~ /(.+)\.rb$/
+        base = $1
+        puts "\033]0;mrdialog - #{base}\007"
+      end
+    end
+
+    text = <<EOF
+This example is taken from dialog/samples/radiolist
+shell script.
+
+Hi, this is a radiolist box. You can use this to
+present a list of choices which can be turned on or
+off. If there are more items than can fit on the
+screen, the list will be scrolled. You can use the
+UP/DOWN arrow keys, the first letter of the choice as a
+hot key, or the number keys 1-9 to choose an option.
+Press SPACE to toggle an option on/off. Set the option
+notags to true if you don't want to diaplay the tags.
+
+  Which of the following are fruits?
+
+EOF
+    items = []
+    checklist_data = Struct.new(:tag, :item, :select)
+
+    data = checklist_data.new
+    data.tag = "Apple"
+    data.item = "It's an applie"
+    data.select = false
+    items.push(data.to_a)
+
+    data = checklist_data.new
+    data.tag = "Dog"
+    data.item = "No it's not my dog"
+    data.select = true
+    items.push(data.to_a)
+
+    data = checklist_data.new
+    data.tag = "Orange"
+    data.item = "Yeah! it is juicy"
+    data.select = false
+    items.push(data.to_a)
+
+    data = checklist_data.new
+    data.tag = "Chicken"
+    data.item = "Normally not a pet"
+    data.select = true
+    items.push(data.to_a)
+
+    dialog = MRDialog.new
+#    dialog.notags = false
+#    dialog.dialog_options = "--no-tags"
+    dialog.clear = true
+    dialog.title = "CHECKLIST"
+    dialog.logger = Logger.new(ENV["HOME"] + "/dialog_" + ME + ".log")
+    dialog.extra_button = true
+    dialog.ok_label = "Send"
+    dialog.extra_label = "Save"
+    dialog.cancel_label = "Quit"
+
+    selected_items = dialog.checklist(text, items)
+    exit_code = dialog.exit_code
+    puts selected_items.class
+    puts "Exit code: #{exit_code}"
+    if selected_items
+      puts "Selected Items:"
+      selected_items.each do |item|
+        puts "  '#{item}'"
+      end
+    end
+
+rescue => e
+    puts "#{$!}"
+    t = e.backtrace.join("\n\t")
+    puts "Error: #{t}"
+end

--- a/samples/extra_button/form1.rb
+++ b/samples/extra_button/form1.rb
@@ -1,0 +1,101 @@
+#!/usr/bin/env ruby
+
+# muquit@muquit.com Apr-01-2014 
+require [File.expand_path(File.dirname(__FILE__)), '../..', 'lib', 'mrdialog'].join('/')
+require 'pp'
+
+begin
+    ME = File.basename($0)
+    if ENV['CHANGE_TITLE']
+      if ME =~ /(.+)\.rb$/
+        base = $1
+        puts "\033]0;mrdialog - #{base}\007"
+      end
+    end
+
+    user = ''
+    uid = ''
+    gid = ''
+    home = ENV["HOME"]
+
+    id = `id`.chomp
+    if id =~ /^uid=(\d+)\((.+)\)\sgid=(\d+)\(.*$/
+        uid = $1
+        user = $2
+        gid = $3
+    end
+
+    dialog = MRDialog.new
+    dialog.clear = true
+    dialog.logger = Logger.new(ENV["HOME"] + "/dialog_" + ME + ".log")
+
+    text = <<EOF
+Here is a possible piece of a configuration program.
+EOF
+    items = []
+    form_data = Struct.new(:label, :ly, :lx, :item, :iy, :ix, :flen, :ilen)
+
+    data = form_data.new
+    data.label = "Username:"
+    data.ly = 1
+    data.lx = 1
+    data.item = user
+    data.iy = 1
+    data.ix = 10
+    data.flen = user.length + 10
+    data.ilen = 0
+    items.push(data.to_a)
+
+    data = form_data.new
+    data.label = "UID:"
+    data.ly = 2 
+    data.lx = 1
+    data.item = uid.to_s
+    data.iy = 2
+    data.ix = 10
+    data.flen = uid.length + 10
+    data.ilen = 0
+    items.push(data.to_a)
+
+    data = form_data.new
+    data.label = "GID:"
+    data.ly = 3
+    data.lx = 1
+    data.item = gid.to_s
+    data.iy =3 
+    data.ix = 10
+    data.flen = gid.length + 2
+    data.ilen = 0
+    items.push(data.to_a)
+
+    data = form_data.new
+    data.label = "HOME:"
+    data.ly = 4
+    data.lx = 1
+    data.item = home
+    data.iy = 4
+    data.ix = 10
+    data.flen = home.length + 40
+    data.ilen = 0
+    items.push(data.to_a)
+
+    dialog.title = "FORM"
+    dialog.extra_button = true
+    dialog.ok_label = "Save"
+    dialog.extra_label = "Submit"
+    dialog.cancel_label = "Quit"
+
+    result_hash = dialog.form(text, items, 20, 50, 0)
+    if result_hash
+        puts "Resulting data:"
+        result_hash.each do |key, val|
+            puts "   #{key} = #{val}"
+        end
+    end
+
+
+rescue => e
+    puts "#{$!}"
+    t = e.backtrace.join("\n\t")
+    puts "Error: #{t}"
+end

--- a/samples/extra_button/fselect.rb
+++ b/samples/extra_button/fselect.rb
@@ -13,11 +13,6 @@ begin
       end
     end
 
-    text = <<EOF
-Please set the time...
-EOF
-
-
     dialog = MRDialog.new
     dialog.clear = true
     dialog.title = "Please choose a file"

--- a/samples/extra_button/fselect.rb
+++ b/samples/extra_button/fselect.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+
+# muquit@muquit.com Apr-01-2014 
+require [File.expand_path(File.dirname(__FILE__)), '../..', 'lib', 'mrdialog'].join('/')
+require 'pp'
+
+begin
+    ME = File.basename($0)
+    if ENV['CHANGE_TITLE']
+      if ME =~ /(.+)\.rb$/
+        base = $1
+        puts "\033]0;mrdialog - #{base}\007"
+      end
+    end
+
+    text = <<EOF
+Please set the time...
+EOF
+
+
+    dialog = MRDialog.new
+    dialog.clear = true
+    dialog.title = "Please choose a file"
+    dialog.extra_button = true
+    dialog.ok_label = "Copy"
+    dialog.extra_label = "Delete"
+    dialog.cancel_label = "Quit"
+
+    h = 14
+    w = 48
+    file_path = ENV["HOME"] + "/"
+    file = dialog.fselect(file_path, h, w)
+
+    puts "Exit code: #{dialog.exit_code}"
+    puts "Result is: #{file}"
+
+rescue => e
+    puts "#{$!}"
+    t = e.backtrace.join("\n\t")
+    puts "Error: #{t}"
+end

--- a/samples/extra_button/inputbox.rb
+++ b/samples/extra_button/inputbox.rb
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+
+# muquit@muquit.com Apr-01-2014 
+require [File.expand_path(File.dirname(__FILE__)), '../..', 'lib', 'mrdialog'].join('/')
+require 'pp'
+
+begin
+  ME = File.basename($0)
+  if ENV['CHANGE_TITLE']
+    if ME =~ /(.+)\.rb$/
+      base = $1
+      puts "\033]0;mrdialog - #{base}\007"
+    end
+  end
+
+  text = <<EOF
+Hi, this is an input dialog box. You can use
+this to ask questions that require the user
+to input a string as the answer. You can
+input strings of length longer than the
+width of the input box, in that case, the
+input field will be automatically scrolled.
+You can use BACKSPACE to correct errors. 
+Try entering your name below:
+
+EOF
+  dialog = MRDialog.new
+  dialog.logger = Logger.new(ENV["HOME"] + "/dialog_" + ME + ".log")
+  dialog.clear = true
+  dialog.title = "INPUT BOX"
+  dialog.extra_button = true
+  dialog.ok_label = "Send"
+  dialog.extra_label = "Save"
+  dialog.cancel_label = "Quit"
+
+  height = 16
+  width = 51
+  init = "blah"
+  result = dialog.inputbox(text, height, width, init)
+
+  puts "Exit Code: #{dialog.exit_code}"
+  puts "Result is: #{result}"
+
+rescue => e
+  puts "#{$!}"
+  t = e.backtrace.join("\n\t")
+  puts "Error: #{t}"
+end

--- a/samples/extra_button/menubox.rb
+++ b/samples/extra_button/menubox.rb
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+
+# muquit@muquit.com Apr-01-2014 
+require [File.expand_path(File.dirname(__FILE__)), '../..', 'lib', 'mrdialog'].join('/')
+begin
+  ME = File.basename($0)
+  if ENV['CHANGE_TITLE']
+    if ME =~ /(.+)\.rb$/
+      base = $1
+      puts "\033]0;mrdialog - #{base}\007"
+    end
+  end
+
+  dialog = MRDialog.new
+  dialog.logger = Logger.new(ENV["HOME"] + "/dialog_" + ME + ".log")
+  dialog.clear = true
+  dialog.title = "MENU BOX"
+  dialog.extra_button = true
+  dialog.ok_label = "Send"
+  dialog.extra_label = "Save"
+  dialog.cancel_label = "Quit"
+
+
+  text = <<EOF
+This example is taken from dialog/samples/menubox1
+
+Hi, this is a menu box. You can use this to
+present a list of choices for the user to
+choose. If there are more items than can fit
+on the screen, the menu will be scrolled.
+You can use the UP/DOWN arrow keys, the first
+letter of the choice as a hot key, or the
+number keys 1-9 to choose an option.
+Try it now!
+
+Choose the OS you like:
+
+EOF
+  items = []
+  menu_data = Struct.new(:tag, :item)
+  data = menu_data.new
+  data.tag = "Linux"
+  data.item = "The Great Unix Clone for 386/486"
+  items.push(data.to_a)
+
+  data = menu_data.new
+  data.tag = "NetBSD"
+  data.item = "Another free Unix Clone for 386/486"
+  items.push(data.to_a)
+
+  data = menu_data.new
+  data.tag = "OS/2"
+  data.item = "IBM OS/2"
+  items.push(data.to_a)
+
+  data = menu_data.new
+  data.tag = "WIN NT" 
+  data.item = "Microsoft Windows NT"
+  items.push(data.to_a)
+
+  data = menu_data.new
+  data.tag = "PCDOS"
+  data.item = "IBM PC DOS"
+  items.push(data.to_a)
+
+  data = menu_data.new
+  data.tag = "MSDOS"  
+  data.item = "Microsoft DOS"
+  items.push(data.to_a)
+
+
+  height = 0
+  width = 0
+  menu_height = 4
+  
+  selected_item = dialog.menu(text, items, height, width, menu_height)
+
+  puts "Exit Code: #{dialog.exit_code}"
+  puts "Selected item: #{selected_item}"
+
+rescue => e
+  puts "#{$!}"
+  t = e.backtrace.join("\n\t")
+  puts "Error: #{t}"
+end

--- a/samples/extra_button/password.rb
+++ b/samples/extra_button/password.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+# muquit@muquit.com Apr-01-2014 
+require [File.expand_path(File.dirname(__FILE__)), '../..', 'lib', 'mrdialog'].join('/')
+require 'pp'
+
+begin
+  ME = File.basename($0)
+  if ENV['CHANGE_TITLE']
+    if ME =~ /(.+)\.rb$/
+      base = $1
+      puts "\033]0;mrdialog - #{base}\007"
+    end
+  end
+
+  text = <<EOF
+Hi, this is an password dialog box. You can use
+this to ask questions that require the user
+to input a string as the answer. You can
+input strings of length longer than the 
+width of the input box, in that case, the
+input field will be automatically scrolled.
+You can use BACKSPACE to correct errors.
+Try entering your name below:
+
+EOF
+  dialog = MRDialog.new
+  dialog.logger = Logger.new(ENV["HOME"] + "/dialog_" + ME + ".log")
+  dialog.clear = true
+  dialog.title = "Password box"
+  dialog.extra_button = true
+  dialog.ok_label = "Login"
+  dialog.extra_label = "Reset"
+  dialog.cancel_label = "Quit"
+
+  result = dialog.passwordbox(text)
+
+  puts "Exit Code: #{dialog.exit_code}"
+  puts "Result is: #{result}"
+
+rescue => e
+  puts "#{$!}"
+  t = e.backtrace.join("\n\t")
+  puts "Error: #{t}"
+end

--- a/samples/extra_button/radiolist.rb
+++ b/samples/extra_button/radiolist.rb
@@ -1,0 +1,86 @@
+#!/usr/bin/env ruby
+
+# muquit@muquit.com Apr-01-2014 
+require [File.expand_path(File.dirname(__FILE__)), '../..', 'lib', 'mrdialog'].join('/')
+require 'pp'
+
+class TestRadiolist
+  ME = File.basename($0)
+
+  def initialize
+    if ENV['CHANGE_TITLE']
+      if ME =~ /(.+)\.rb$/
+        base = $1
+        puts "\033]0;mrdialog - #{base}\007"
+      end
+    end
+  end
+
+  def doit
+    dialog = MRDialog.new
+    dialog.clear = true
+    dialog.logger = Logger.new(ENV["HOME"] + "/dialog_" + ME + ".log")
+
+  text = <<EOF
+This example is taken from dialog/samples/radiolist
+shell script.
+
+Hi, this is a radiolist box. You can use this to
+present a list of choices which can be turned on or
+off. If there are more items than can fit on the
+screen, the list will be scrolled. You can use the
+UP/DOWN arrow keys, the first letter of the choice as a
+hot key, or the number keys 1-9 to choose an option.
+Press SPACE to toggle an option on/off.
+
+  Which of the following are fruits?
+
+EOF
+      items = []
+      radiolist_data = Struct.new(:tag, :item, :select)
+
+      data = radiolist_data.new
+      data.tag = "Apple"
+      data.item = "It's an applie"
+      data.select = false
+      items.push(data.to_a)
+
+      data = radiolist_data.new
+      data.tag = "Dog"
+      data.item = "No it's not my dog"
+      data.select = true
+      items.push(data.to_a)
+
+      data = radiolist_data.new
+      data.tag = "Orange"
+      data.item = "Yeah! it is juicy"
+      data.select = false
+      items.push(data.to_a)
+
+      dialog.title = "RADIOLIST"
+      dialog.extra_button = true
+      dialog.ok_label = "Edit"
+      dialog.extra_label = "Delete"
+      dialog.cancel_label = "Quit"
+  
+      selected_item = dialog.radiolist(text, items)
+      exit_code = dialog.exit_code
+      case exit_code
+      when dialog.dialog_ok
+          puts "OK Pressed"
+      when dialog.dialog_extra
+          puts "Extra Pressed"
+      when dialog.dialog_cancel
+          puts "Cancel Pressed"
+      when dialog.dialog_esc
+          puts "Escape Pressed"
+      end
+
+      puts "Selected item: #{selected_item}"
+  end
+end
+
+if __FILE__ == $0
+  TestRadiolist.new.doit
+end
+

--- a/samples/extra_button/timebox.rb
+++ b/samples/extra_button/timebox.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+
+# muquit@muquit.com Apr-01-2014 
+require [File.expand_path(File.dirname(__FILE__)), '../..', 'lib', 'mrdialog'].join('/')
+require 'pp'
+
+begin
+  ME = File.basename($0)
+  if ENV['CHANGE_TITLE']
+    if ME =~ /(.+)\.rb$/
+      base = $1
+      puts "\033]0;mrdialog - #{base}\007"
+    end
+  end
+
+  text = <<EOF
+Please set the time...
+EOF
+
+  h = 0
+  w = 0
+  t = Time.new
+
+  dialog = MRDialog.new
+  dialog.logger = Logger.new(ENV["HOME"] + "/dialog_" + ME + ".log")
+  dialog.clear = true
+  dialog.title = "TIEMBOX"
+  dialog.extra_button = true
+  dialog.ok_label = "Event"
+  dialog.extra_label = "Alert"
+  dialog.cancel_label = "Quit"
+
+  # return Time
+  time = dialog.timebox(text, h, w, t)
+
+  puts "Exit Code: #{dialog.exit_code}"
+  puts "time: #{time}"
+
+rescue => e
+  puts "#{$!}"
+  t = e.backtrace.join("\n\t")
+  puts "Error: #{t}"
+end

--- a/samples/extra_button/treeview.rb
+++ b/samples/extra_button/treeview.rb
@@ -1,0 +1,112 @@
+#!/usr/bin/env ruby
+
+# muquit@muquit.com Apr-20-2014 
+require [File.expand_path(File.dirname(__FILE__)), '../..', 'lib', 'mrdialog'].join('/')
+require 'pp'
+
+begin
+    ME = File.basename($0)
+    if ENV['CHANGE_TITLE']
+      if ME =~ /(.+)\.rb$/
+        base = $1
+        puts "\033]0;mrdialog - #{base}\007"
+      end
+    end
+
+    text = <<-EOF
+This example is taken from dialog/samples/treeview1
+shell script.
+
+EOF
+    items = []
+    Struct.new("TreeviewData", :tag, :item, :status, :depth)
+    data = Struct::TreeviewData.new
+
+    data.tag = "tag1"
+    data.item = "Item number 1"
+    data.status = false
+    data.depth = 0
+    items.push(data.to_a)
+
+    data = Struct::TreeviewData.new
+    data.tag = "tag2"
+    data.item = "Item number 2"
+    data.status = false
+    data.depth = 1
+    items.push(data.to_a)
+
+    data = Struct::TreeviewData.new
+    data.tag = "tag3"
+    data.item = "Item number 3"
+    data.status = true
+    data.depth = 2
+    items.push(data.to_a)
+
+    data = Struct::TreeviewData.new
+    data.tag = "tag4"
+    data.item = "Item number 4"
+    data.status = false
+    data.depth = 1
+    items.push(data.to_a)
+
+    data = Struct::TreeviewData.new
+    data.tag = "tag5"
+    data.item = "Item number 5"
+    data.status = false
+    data.depth = 2
+    items.push(data.to_a)
+
+    data = Struct::TreeviewData.new
+    data.tag = "tag6"
+    data.item = "Item number 6"
+    data.status = false
+    data.depth = 3
+    items.push(data.to_a)
+
+    data = Struct::TreeviewData.new
+    data.tag = "tag7"
+    data.item = "Item number 7"
+    data.status = false
+    data.depth = 3
+    items.push(data.to_a)
+
+    data = Struct::TreeviewData.new
+    data.tag = "tag8"
+    data.item = "Item number 8"
+    data.status = false
+    data.depth = 4
+    items.push(data.to_a)
+
+    data = Struct::TreeviewData.new
+    data.tag = "tag9"
+    data.item = "Item number 9"
+    data.status = false
+    data.depth = 1
+    items.push(data.to_a)
+
+    dialog = MRDialog.new
+    dialog.clear = true
+    dialog.title = "TREEVIEW"
+    dialog.logger = Logger.new(ENV["HOME"] + "/dialog_" + ME + ".log")
+    dialog.extra_button = true
+    dialog.ok_label = "Edit"
+    dialog.extra_label = "Delete"
+    dialog.cancel_label = "Quit"
+
+
+    height = 0
+    width = 0
+    listheight = 0
+
+    selected_tag = dialog.treeview(text, items, height, width, listheight)
+    exit_code = dialog.exit_code
+    puts "Exit code: #{exit_code}"
+    if exit_code != 1
+      puts "Selected tag: #{selected_tag}"
+    end
+
+rescue => e
+    puts "#{$!}"
+    t = e.backtrace.join("\n\t")
+    puts "Error: #{t}"
+end

--- a/samples/run_all.rb
+++ b/samples/run_all.rb
@@ -39,7 +39,7 @@ EOF
     pwd = Dir.pwd
     entries = Dir.entries(pwd)
     entries.each do |prog|
-      next if prog == '.' || prog == '..' || prog =~ /run_all.rb/
+      next if prog =~ /run_all.rb/ || prog !~ /\.rb$/
       cmd = ""
       cmd << "ruby ./#{prog}"
       system(cmd)


### PR DESCRIPTION
Previously only the OK/Yes button read input from forms, menus and lists. If an extra button is used, it was treated the same as the Cancel/No button, and no output from the form/menu/list was returned to the caller. 

This PR changes the various user input dialogs to treat the Extra button the same way as the OK/Yes button, and to return the dialog's input to the caller. 

Usage examples are stored in samples/extra_button directory (which is excluded from the run_all.rb script)